### PR TITLE
Update links to travis-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CEAS Ambassadors Website
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/kurtlewis/ceas-ambassadors-website.svg)](https://greenkeeper.io/)
-[![Build Status](https://travis-ci.org/kurtlewis/ceas-ambassadors-website.svg?branch=master)](https://travis-ci.org/kurtlewis/ceas-ambassadors-website)
+[![Build Status](https://travis-ci.org/ceas-ambassadors/ceas-ambassadors-website.svg?branch=master)](https://travis-ci.org/ceas-ambassadors/ceas-ambassadors-website)
 
 This repository is home to a rewrite of [the old ambassador's website](https://github.com/kurtlewis/OrganizationManager).
 
@@ -11,3 +11,5 @@ Comprehensive docs can be found in the `docs` folder. Instructions for getting s
 
 ## Functionality
 This website is used to faciliate operations for a student tour group for the University of Cincinnati College of Engineering and Applied Science. It is home to tour listings, member management, and profiles on existing members. Members can sign up for tours they'd like to give, view their progress towards membership requirements, and update details on their involvement.
+
+

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -130,7 +130,7 @@ To write tests, start by looking at existing tests - they are probably the easie
 We'll follow the [Airbnb style guide](https://github.com/airbnb/javascript). I chose this because it was the most popular javascript style guide at the time of writing. It is enforced by a linter run on the Travis CI build. You can run it locally by running `npm run lint` after running `npm install`.
 
 ## Build Tool
-This project automatically triggers a run of tests and the linter on every push to Github. This is configured through our `.travis.yml` file. The build history can be accessed [here](https://travis-ci.org/kurtlewis/ceas-ambassadors-website).
+This project automatically triggers a run of tests and the linter on every push to Github. This is configured through our `.travis.yml` file. The build history can be accessed [here](https://travis-ci.org/ceas-ambassadors/ceas-ambassadors-website).
 
 
 ## Version Control


### PR DESCRIPTION
This is a test to see if travis ci works correctly. 

Updating links in repo to refer to the organization instead of kurtlewis