### PR TITLE
Update Sequelize to v5.8.6

### DIFF
--- a/app.js
+++ b/app.js
@@ -207,7 +207,7 @@ passport.serializeUser((user, done) => {
 
 // converts the cookie from the client into an instance of Member upon a request
 passport.deserializeUser((id, done) => {
-  models.Member.findById(id).then((member) => {
+  models.Member.findByPk(id).then((member) => {
     return done(null, member);
   }).catch((err) => {
     return done(err, null);

--- a/controllers/event.js
+++ b/controllers/event.js
@@ -11,7 +11,7 @@ const models = require('../models/');
  * @param {*} res - outgoing response
  */
 const getDetails = (req, res, next) => {
-  return models.Event.findById(req.params.id).then((event) => {
+  return models.Event.findByPk(req.params.id).then((event) => {
     if (!event) {
       req.session.status = 404;
       req.session.alert.errorMessages.push('Event not found.');
@@ -260,7 +260,7 @@ const postCreateEdit = [
     }
 
     if (req.body.isEdit === 'true') {
-      return models.Event.findById(req.body.eventId).then((event) => {
+      return models.Event.findByPk(req.body.eventId).then((event) => {
         // For edits, switching between meetings and non-meetings is disallowed
         if (isMeeting !== event.meeting) {
           // The UI doesn't even display meeting check box, so just set it back to the default
@@ -325,7 +325,7 @@ const postSignup = (req, res, next) => {
   }
 
   // Get the event
-  const eventPromise = models.Event.findById(req.params.id);
+  const eventPromise = models.Event.findByPk(req.params.id);
 
   // Get the member
   let memberEmail = null;
@@ -542,7 +542,7 @@ const postDelete = (req, res, next) => {
     });
   }
 
-  return models.Event.findById(req.params.id).then((event) => {
+  return models.Event.findByPk(req.params.id).then((event) => {
     if (!event) {
       // event was not found - 404
       req.session.status = 404;
@@ -586,7 +586,7 @@ const getEdit = (req, res, next) => {
     });
   }
   // get event
-  return models.Event.findById(req.params.id).then((event) => {
+  return models.Event.findByPk(req.params.id).then((event) => {
     if (!event) {
       req.session.status = 404;
       req.session.alert.errorMessages.push('Event not found.');

--- a/controllers/member.js
+++ b/controllers/member.js
@@ -385,7 +385,7 @@ const getProfile = (req, res, next) => {
     type: models.sequelize.QueryTypes.SELECT,
   });
 
-  const memberPromise = models.Member.findById(req.params.id);
+  const memberPromise = models.Member.findByPk(req.params.id);
 
   return Promise.all([memberPromise, eventPromise]).then(([member, events]) => {
     if (!member) {
@@ -511,7 +511,7 @@ const postUpdateAttributes = (req, res, next) => {
     });
   }
   // get the requested member
-  return models.Member.findById(req.params.id).then((member) => {
+  return models.Member.findByPk(req.params.id).then((member) => {
     if (!member) {
       // member not found, 404
       req.session.status = 404;
@@ -585,7 +585,7 @@ const postDelete = (req, res, next) => {
   }
 
   // Get the member
-  return models.Member.findById(req.params.id).then((member) => {
+  return models.Member.findByPk(req.params.id).then((member) => {
     if (!member) {
       req.session.status = 404;
       req.session.alert.errorMessages.push('Member not found.');
@@ -644,7 +644,7 @@ const postResetPassword = (req, res, next) => {
   // randomly generate password
   const password = Math.random().toString(36).substr(2, 8);
   // Find the member
-  const memberPromise = models.Member.findById(req.params.id);
+  const memberPromise = models.Member.findByPk(req.params.id);
 
   const passwordPromise = models.Member.generatePasswordHash(password);
 

--- a/models/attendance.js
+++ b/models/attendance.js
@@ -19,6 +19,9 @@ module.exports = (sequelize, DataTypes) => {
   }, {
     // set so that all autocreated table names are underscored instead of camel cased
     underscored: true,
+    // manually name our table. the use of the 'underscored' option would
+    // decapitilize the first word.
+    tableName: 'Attendances',
     hooks: {
       beforeUpsert: () => {
         // Disallow upserts because they're difficult to support with our hook ecosystem
@@ -26,7 +29,7 @@ module.exports = (sequelize, DataTypes) => {
       },
       beforeCreate: (attendance /* , options */) => {
         // validate that if the event is a meeting, it isn't a not_needed record
-        return sequelize.models.Event.findById(attendance.event_id).then((event) => {
+        return sequelize.models.Event.findByPk(attendance.event_id).then((event) => {
           if (event.meeting && attendance.status === Attendance.getStatusNotNeeded()) {
             throw Error('Meetings cannot have not needed status.');
           }
@@ -34,7 +37,7 @@ module.exports = (sequelize, DataTypes) => {
       },
       beforeUpdate: (attendance /* , options */) => {
         // validate that if the event is a meeting, it isn't being updated to a not_needed record
-        return sequelize.models.Event.findById(attendance.event_id).then((event) => {
+        return sequelize.models.Event.findByPk(attendance.event_id).then((event) => {
           if (event.meeting && attendance.status === Attendance.getStatusNotNeeded()) {
             throw Error('Meetings cannot have not needed status.');
           }
@@ -48,9 +51,9 @@ module.exports = (sequelize, DataTypes) => {
           // No action needed. Resolve with empty promise for consistent return value
           return Promise.resolve();
         }
-        const eventPromise = sequelize.models.Event.findById(attendance.event_id);
+        const eventPromise = sequelize.models.Event.findByPk(attendance.event_id);
 
-        const memberPromise = sequelize.models.Member.findById(attendance.member_id);
+        const memberPromise = sequelize.models.Member.findByPk(attendance.member_id);
 
         return Promise.all([eventPromise, memberPromise]).then((output) => {
           const event = output[0];
@@ -88,9 +91,9 @@ module.exports = (sequelize, DataTypes) => {
           return Promise.resolve();
         }
 
-        const eventPromise = sequelize.models.Event.findById(attendance.event_id);
+        const eventPromise = sequelize.models.Event.findByPk(attendance.event_id);
 
-        const memberPromise = sequelize.models.Member.findById(attendance.member_id);
+        const memberPromise = sequelize.models.Member.findByPk(attendance.member_id);
 
         return Promise.all([eventPromise, memberPromise]).then((output) => {
           const event = output[0];
@@ -146,9 +149,9 @@ module.exports = (sequelize, DataTypes) => {
           // No action needed. Resolve with empty promise for consistent return value
           return Promise.resolve();
         }
-        const eventPromise = sequelize.models.Event.findById(attendance.event_id);
+        const eventPromise = sequelize.models.Event.findByPk(attendance.event_id);
 
-        const memberPromise = sequelize.models.Member.findById(attendance.member_id);
+        const memberPromise = sequelize.models.Member.findByPk(attendance.member_id);
 
         return Promise.all([eventPromise, memberPromise]).then((output) => {
           const event = output[0];

--- a/models/event.js
+++ b/models/event.js
@@ -35,6 +35,9 @@ module.exports = (sequelize, DataTypes) => {
   }, {
     // set so that all autocreated table names are underscored instead of camel cased
     underscored: true,
+    // manually name the table, the use of the 'underscored' option would
+    // rename it without a capital letter
+    tableName: 'Events',
     hooks: {
       // http://docs.sequelizejs.com/manual/tutorial/hooks.html
       beforeUpsert: () => {
@@ -84,7 +87,7 @@ module.exports = (sequelize, DataTypes) => {
         }).then((attendances) => {
           const promises = [];
           for (let i = 0; i < attendances.length; i += 1) {
-            promises.push(sequelize.models.Member.findById(attendances[i].member_id));
+            promises.push(sequelize.models.Member.findByPk(attendances[i].member_id));
           }
           return Promise.all(promises).then((output) => {
             const returns = []; // array of actions for return
@@ -121,6 +124,7 @@ module.exports = (sequelize, DataTypes) => {
     // associations can be defined here
     models.Event.belongsToMany(models.Member, {
       as: 'event_id',
+      foreignKey: 'event_id', // names what the column appears as in code
       through: models.Attendance,
       hooks: true,
     });

--- a/models/member.js
+++ b/models/member.js
@@ -56,11 +56,15 @@ module.exports = (sequelize, DataTypes) => {
   }, {
     // set so that all autocreated table names are underscored instead of camel cased
     underscored: true,
+    // manually name the table. the use of 'underscored' would change the name
+    // to not have a capital letter
+    tableName: 'Members',
   });
   Member.associate = (models) => {
     // associations can be defined here
     models.Member.belongsToMany(models.Event, {
       as: 'member_id',
+      foreignKey: 'member_id', // names what the column appears as in code
       through: models.Attendance,
     });
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,15 +17,10 @@
         "@types/babel-types": "7.0.2"
       }
     },
-    "@types/geojson": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",
-      "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
-    },
     "@types/node": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.0.tgz",
-      "integrity": "sha512-kctoM36XiNZT86a7tPsUje+Q/yl+dqELjtYApi0T5eOQ90Elhu0MI10rmYk44yEP4v1jdDvtjQ9DFtpRtHf2Bw=="
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.3.tgz",
+      "integrity": "sha512-zkOxCS/fA+3SsdA+9Yun0iANxzhQRiNwTvJSr6N95JhuJ/x27z9G2URx1Jpt3zYFfCGUXZGL5UDxt5eyLE7wgw=="
     },
     "@types/semver": {
       "version": "5.5.0",
@@ -141,6 +136,11 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
       "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "append-field": {
       "version": "1.0.0",
@@ -1004,7 +1004,7 @@
       "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
       "requires": {
         "is-bluebird": "1.0.2",
-        "shimmer": "1.2.0"
+        "shimmer": "1.2.1"
       }
     },
     "code-point-at": {
@@ -1393,9 +1393,9 @@
       "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg=="
     },
     "dottie": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.0.tgz",
-      "integrity": "sha1-2hkZgci41xPKARXViYzzl8Lw3dA="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.1.tgz",
+      "integrity": "sha512-ch5OQgvGDK2u8pSZeSYAQaV/lczImd7pMJ7BcEPXmnFVjy4yJIzP6CsODJUTH8mg1tyH1Z2abOiuJO3DjZ/GBw=="
     },
     "editorconfig": {
       "version": "0.15.2",
@@ -2092,11 +2092,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-    },
-    "generic-pool": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.4.2.tgz",
-      "integrity": "sha512-H7cUpwCQSiJmAHM4c/aFu6fUfrhWXW1ncyh8ftxEPMu6AiYkHw9K8br720TGPZJbk5eOH2bynjZD1yPvdDAmag=="
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -3010,16 +3005,16 @@
       }
     },
     "moment": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
-      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moment-timezone": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.16.tgz",
-      "integrity": "sha512-4d1l92plNNqnMkqI/7boWNVXJvwGL2WyByl1Hxp3h/ao3HZiAqaoQY+6KBkYdiN5QtNDpndq+58ozl8W4GVoNw==",
+      "version": "0.5.25",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.25.tgz",
+      "integrity": "sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==",
       "requires": {
-        "moment": "2.22.1"
+        "moment": "2.24.0"
       }
     },
     "morgan": {
@@ -3892,22 +3887,11 @@
       }
     },
     "retry-as-promised": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.3.2.tgz",
-      "integrity": "sha1-zZdO5P2bX+A8vzGHHuSCIcB3N7c=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-3.2.0.tgz",
+      "integrity": "sha512-CybGs60B7oYU/qSQ6kuaFmRd9sTZ6oXSc0toqePvV74Ac6/IFZSI1ReFQmtCN+uvW1Mtqdwpvt/LGOiCBAY2Mg==",
       "requires": {
-        "bluebird": "3.5.1",
-        "debug": "2.6.9"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
+        "any-promise": "1.3.0"
       }
     },
     "right-align": {
@@ -3958,7 +3942,8 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
     },
     "send": {
       "version": "0.16.2",
@@ -4007,36 +3992,49 @@
       "integrity": "sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4="
     },
     "sequelize": {
-      "version": "4.37.6",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.37.6.tgz",
-      "integrity": "sha512-x/6099L+6+3LQWms23wng/AR6yUE3X/VhrwSTSMbgOIk2ELY3DchI/9f9Ii7LIQRPxW1BHGpwboH7kxS/froXg==",
+      "version": "5.8.6",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.8.6.tgz",
+      "integrity": "sha512-u6KJuMBNLAE44PkGUTlevBseb6BV/n5r8CDGmYe1VxcGxdlWXYUiNXlEFEW0OL6ie+yXYV7dnPHa/fDi1M7gMw==",
       "requires": {
         "bluebird": "3.5.1",
         "cls-bluebird": "2.1.0",
-        "debug": "3.1.0",
-        "depd": "1.1.2",
-        "dottie": "2.0.0",
-        "generic-pool": "3.4.2",
+        "debug": "4.1.1",
+        "dottie": "2.0.1",
         "inflection": "1.12.0",
-        "lodash": "4.17.10",
-        "moment": "2.22.1",
-        "moment-timezone": "0.5.16",
-        "retry-as-promised": "2.3.2",
-        "semver": "5.5.0",
-        "terraformer-wkt-parser": "1.1.2",
+        "lodash": "4.17.11",
+        "moment": "2.24.0",
+        "moment-timezone": "0.5.25",
+        "retry-as-promised": "3.2.0",
+        "semver": "5.7.0",
+        "sequelize-pool": "1.0.2",
         "toposort-class": "1.0.1",
-        "uuid": "3.2.1",
-        "validator": "9.4.1",
-        "wkx": "0.4.4"
+        "uuid": "3.3.2",
+        "validator": "10.11.0",
+        "wkx": "0.4.6"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.1"
           }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
         }
       }
     },
@@ -4147,6 +4145,21 @@
         }
       }
     },
+    "sequelize-pool": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-1.0.2.tgz",
+      "integrity": "sha512-VMKl/gCCdIvB1gFZ7p+oqLFEyZEz3oMMYjkKvfEC7GoO9bBcxmfOOU9RdkoltfXGgBZFigSChihRly2gKtsh2w==",
+      "requires": {
+        "bluebird": "3.5.5"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.5",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
+        }
+      }
+    },
     "serve-favicon": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.5.0.tgz",
@@ -4204,9 +4217,9 @@
       "dev": true
     },
     "shimmer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz",
-      "integrity": "sha512-xTCx2vohXC2EWWDqY/zb4+5Mu28D+HYNSOuFzsyRDRvI/e1ICb69afwaUwfjr+25ZXldbOLyp+iDUZHq8UnTag=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "sigmund": {
       "version": "1.0.1",
@@ -4445,22 +4458,6 @@
         "string-width": "2.1.1"
       }
     },
-    "terraformer": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/terraformer/-/terraformer-1.0.8.tgz",
-      "integrity": "sha1-UeCtiXRvzyFh3G9lqnDkI3fItZM=",
-      "requires": {
-        "@types/geojson": "1.0.6"
-      }
-    },
-    "terraformer-wkt-parser": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.1.2.tgz",
-      "integrity": "sha1-M2oMj8gglKWv+DKI9prt7NNpvww=",
-      "requires": {
-        "terraformer": "1.0.8"
-      }
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4607,9 +4604,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.3",
@@ -4622,9 +4619,9 @@
       }
     },
     "validator": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
-      "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
     },
     "vary": {
       "version": "1.1.2",
@@ -4675,11 +4672,11 @@
       }
     },
     "wkx": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.4.tgz",
-      "integrity": "sha512-eVVHka2jRaAp9QanKhLpxWs3AGDV0b8cijlavxBnn4ryXzq5N/3Xe3nkQsI0XMRA16RURwviCWuOCj4mXCmrxw==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.6.tgz",
+      "integrity": "sha512-LHxXlzRCYQXA9ZHgs8r7Gafh0gVOE8o3QmudM1PIkOdkXXjW7Thcl+gb2P2dRuKgW8cqkitCRZkkjtmWzpHi7A==",
       "requires": {
-        "@types/node": "10.0.0"
+        "@types/node": "12.0.3"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
     "pug": "2.0.3",
-    "sequelize": "^4.37.6",
+    "sequelize": "^5.8.6",
     "serve-favicon": "^2.5.0"
   },
   "devDependencies": {

--- a/test/account.js
+++ b/test/account.js
@@ -109,7 +109,7 @@ describe('Account Tests', () => {
       .expect(400);
     // check that bad_email@mail.uc.edu was not added to the database
     return response.then(() => {
-      return models.Member.findById('bad_email@mail.uc.edu').then((member) => {
+      return models.Member.findByPk('bad_email@mail.uc.edu').then((member) => {
         assert(!member);
       });
     });
@@ -130,7 +130,7 @@ describe('Account Tests', () => {
       .expect(400);
     // check that bad_email@mail.uc.edu was not added to the database
     return response.then(() => {
-      return models.Member.findById('bad_email@mail.uc.edu').then((member) => {
+      return models.Member.findByPk('bad_email@mail.uc.edu').then((member) => {
         assert(!member);
       });
     });
@@ -151,7 +151,7 @@ describe('Account Tests', () => {
       .expect(400);
     // check that bad_email@mail.uc.edu was not added to the database
     return response.then(() => {
-      return models.Member.findById('bad_email@mail.uc.edu').then((member) => {
+      return models.Member.findByPk('bad_email@mail.uc.edu').then((member) => {
         assert(!member);
       });
     });
@@ -171,7 +171,7 @@ describe('Account Tests', () => {
       .expect(400);
     // check that bad_email@mail.uc.edu was not added to the database
     return response.then(() => {
-      return models.Member.findById('bad_email@mail.uc.edu').then((member) => {
+      return models.Member.findByPk('bad_email@mail.uc.edu').then((member) => {
         assert(!member);
       });
     });
@@ -383,7 +383,7 @@ describe('Account Tests', () => {
         .expect(200);
 
       return response.then(() => {
-        return models.Member.findById(loginMember.id).then((member) => {
+        return models.Member.findByPk(loginMember.id).then((member) => {
           return models.Member.comparePassword('newPassword', member).then((res) => {
             assert(res, 'The new password was not applied.');
           });
@@ -402,7 +402,7 @@ describe('Account Tests', () => {
         .expect(400);
 
       return response.then(() => {
-        return models.Member.findById(loginMember.id).then((member) => {
+        return models.Member.findByPk(loginMember.id).then((member) => {
           return models.Member.comparePassword('newPassword', member).then((res) => {
             assert(!res, 'The new password was wrongfully applied.');
           });
@@ -421,7 +421,7 @@ describe('Account Tests', () => {
         .expect(400);
 
       return response.then(() => {
-        return models.Member.findById(loginMember.id).then((member) => {
+        return models.Member.findByPk(loginMember.id).then((member) => {
           return models.Member.comparePassword('newPassword', member).then((res) => {
             assert(!res, 'The new password was wrongfully applied.');
           });
@@ -440,7 +440,7 @@ describe('Account Tests', () => {
         .expect(400);
 
       return response.then(() => {
-        return models.Member.findById(loginMember.id).then((member) => {
+        return models.Member.findByPk(loginMember.id).then((member) => {
           return models.Member.comparePassword('newPassword', member).then((res) => {
             assert(!res, 'The new password was wrongfully applied.');
           });
@@ -460,7 +460,7 @@ describe('Account Tests', () => {
         .expect(400);
 
       return response.then(() => {
-        return models.Member.findById(loginMember.id).then((member) => {
+        return models.Member.findByPk(loginMember.id).then((member) => {
           return models.Member.comparePassword('newPassword', member).then((res) => {
             assert(!res, 'The new password was wrongfully applied.');
           });
@@ -480,7 +480,7 @@ describe('Account Tests', () => {
         .expect(400);
 
       return response.then(() => {
-        return models.Member.findById(loginMember.id).then((member) => {
+        return models.Member.findByPk(loginMember.id).then((member) => {
           return models.Member.comparePassword('newPassword', member).then((res) => {
             assert(!res, 'The new password was wrongfully applied.');
           });

--- a/test/attendance.js
+++ b/test/attendance.js
@@ -38,7 +38,7 @@ describe('Attendance Tests', () => {
           status: models.Attendance.getStatusUnconfirmed(),
         }).then(() => {
           // assert that the member service didn't change
-          return models.Member.findById(output[1].id).then((member) => {
+          return models.Member.findByPk(output[1].id).then((member) => {
             assert.equal(member.service, 0);
             assert.equal(member.meetings, 0);
             assert.equal(member.service_not_needed, 0);
@@ -57,7 +57,7 @@ describe('Attendance Tests', () => {
           status: models.Attendance.getStatusNotNeeded(),
         }).then(() => {
           // assert that only the member not needed service changed
-          return models.Member.findById(output[1].id).then((member) => {
+          return models.Member.findByPk(output[1].id).then((member) => {
             assert.equal(member.service, 0);
             assert.equal(member.meetings, 0);
             assert.equal(member.service_not_needed, common.getEventLength());
@@ -76,7 +76,7 @@ describe('Attendance Tests', () => {
           status: models.Attendance.getStatusConfirmed(),
         }).then(() => {
           // assert that only the member service changed
-          return models.Member.findById(output[1].id).then((member) => {
+          return models.Member.findByPk(output[1].id).then((member) => {
             assert.equal(member.service, common.getEventLength());
             assert.equal(member.meetings, 0);
             assert.equal(member.service_not_needed, 0);
@@ -98,7 +98,7 @@ describe('Attendance Tests', () => {
             status: models.Attendance.getStatusConfirmed(),
           }).then(() => {
             // assert that only the member service changed
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, common.getEventLength());
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -121,7 +121,7 @@ describe('Attendance Tests', () => {
             status: models.Attendance.getStatusNotNeeded(),
           }).then(() => {
             // assert that only the member not needed service changed
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, common.getEventLength());
@@ -144,7 +144,7 @@ describe('Attendance Tests', () => {
             status: models.Attendance.getStatusUnconfirmed(),
           }).then(() => {
             // assert that the member service didn't change
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -167,7 +167,7 @@ describe('Attendance Tests', () => {
             status: models.Attendance.getStatusConfirmed(),
           }).then(() => {
             // assert that only the member service changed
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, common.getEventLength());
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -190,7 +190,7 @@ describe('Attendance Tests', () => {
             status: models.Attendance.getStatusNotNeeded(),
           }).then(() => {
             // assert that only the member not needed service changed
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, common.getEventLength());
@@ -213,7 +213,7 @@ describe('Attendance Tests', () => {
             status: models.Attendance.getStatusUnconfirmed(),
           }).then(() => {
             // assert that the member service didn't change
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -236,7 +236,7 @@ describe('Attendance Tests', () => {
             status: models.Attendance.getStatusConfirmed(),
           }).then(() => {
             // assert that only the member service changed
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, common.getEventLength());
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -259,7 +259,7 @@ describe('Attendance Tests', () => {
             status: models.Attendance.getStatusNotNeeded(),
           }).then(() => {
             // assert that only the member not needed service changed
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, common.getEventLength());
@@ -282,7 +282,7 @@ describe('Attendance Tests', () => {
             status: models.Attendance.getStatusUnconfirmed(),
           }).then(() => {
             // assert that the member service didn't change
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -303,7 +303,7 @@ describe('Attendance Tests', () => {
         }).then((attendance) => {
           return attendance.destroy().then(() => {
             // assert that the member service didn't change
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -324,7 +324,7 @@ describe('Attendance Tests', () => {
         }).then((attendance) => {
           return attendance.destroy().then(() => {
             // assert that the member service didn't change
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -345,7 +345,7 @@ describe('Attendance Tests', () => {
         }).then((attendance) => {
           return attendance.destroy().then(() => {
             // assert that the member service didn't change
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -366,7 +366,7 @@ describe('Attendance Tests', () => {
           event_id: output[0].id,
           status: models.Attendance.getStatusConfirmed(),
         }).then(() => {
-          return models.Member.findById(output[1].id).then((member) => {
+          return models.Member.findByPk(output[1].id).then((member) => {
             assert.equal(member.service, 0);
             assert.equal(member.meetings, 1);
             assert.equal(member.service_not_needed, 0);
@@ -384,7 +384,7 @@ describe('Attendance Tests', () => {
           event_id: output[0].id,
           status: models.Attendance.getStatusUnconfirmed(),
         }).then(() => {
-          return models.Member.findById(output[1].id).then((member) => {
+          return models.Member.findByPk(output[1].id).then((member) => {
             assert.equal(member.service, 0);
             assert.equal(member.meetings, 0);
             assert.equal(member.service_not_needed, 0);
@@ -419,7 +419,7 @@ describe('Attendance Tests', () => {
           status: models.Attendance.getStatusConfirmed(),
         }).then((attendance) => {
           return attendance.destroy().then(() => {
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -439,7 +439,7 @@ describe('Attendance Tests', () => {
           status: models.Attendance.getStatusUnconfirmed(),
         }).then((attendance) => {
           return attendance.destroy().then(() => {
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -461,7 +461,7 @@ describe('Attendance Tests', () => {
           return attendance.update({
             status: models.Attendance.getStatusConfirmed(),
           }).then(() => {
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 1);
               assert.equal(member.service_not_needed, 0);
@@ -483,7 +483,7 @@ describe('Attendance Tests', () => {
           return attendance.update({
             status: models.Attendance.getStatusUnconfirmed(),
           }).then(() => {
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -529,7 +529,7 @@ describe('Attendance Tests', () => {
             end_time: output[0].start_time.getTime() + (common.getEventLength() / 2),
           }).then(() => {
             // it should not have changed the member because it was unconfirmed
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -553,7 +553,7 @@ describe('Attendance Tests', () => {
             end_time: output[0].start_time.getTime() + (common.getEventLength() / 2),
           }).then(() => {
             // not needed time should have updated to be 1/2 of its previous value
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, (common.getEventLength() / 2));
@@ -577,7 +577,7 @@ describe('Attendance Tests', () => {
             end_time: output[0].start_time.getTime() + (common.getEventLength() / 2),
           }).then(() => {
             // service should now be 1/2 of event length
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, (common.getEventLength() / 2));
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -601,7 +601,7 @@ describe('Attendance Tests', () => {
             end_time: output[0].start_time.getTime() + (common.getEventLength() / 2),
           }).then(() => {
             // changing event times should not impact meetings
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 1);
               assert.equal(member.service_not_needed, 0);
@@ -622,7 +622,7 @@ describe('Attendance Tests', () => {
         }).then(() => {
           return output[0].destroy().then(() => {
             // unconfirmed status should see no difference
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -643,7 +643,7 @@ describe('Attendance Tests', () => {
         }).then(() => {
           return output[0].destroy().then(() => {
             // everything should be 0
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -664,7 +664,7 @@ describe('Attendance Tests', () => {
         }).then(() => {
           return output[0].destroy().then(() => {
             // everything should be 0
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -685,7 +685,7 @@ describe('Attendance Tests', () => {
         }).then(() => {
           return output[0].destroy().then(() => {
             // changing event times should not impact meetings
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -706,7 +706,7 @@ describe('Attendance Tests', () => {
         }).then(() => {
           return output[0].destroy().then(() => {
             // changing event times should not impact meetings
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.service, 0);
               assert.equal(member.meetings, 0);
               assert.equal(member.service_not_needed, 0);
@@ -737,7 +737,7 @@ describe('Attendance Tests', () => {
               member_id: output[1].id,
             },
           }).then(() => {
-            return models.Member.findById(output[1].id).then((member) => {
+            return models.Member.findByPk(output[1].id).then((member) => {
               assert.equal(member.meetings, 0);
             });
           });

--- a/test/event.js
+++ b/test/event.js
@@ -210,7 +210,7 @@ describe('Event Tests', () => {
           });
 
           // events should not increase amount of service attended, added as unconfirmed
-          const memberPromise = models.Member.findById(loginMember.id)
+          const memberPromise = models.Member.findByPk(loginMember.id)
             .then((member) => {
               assert.equal(member.service, 0);
             });
@@ -239,7 +239,7 @@ describe('Event Tests', () => {
           });
 
           // Meeting should not be added to the meeting count
-          const memberPromise = models.Member.findById(loginMember.id)
+          const memberPromise = models.Member.findByPk(loginMember.id)
             .then((member) => {
               assert.equal(member.meetings, 0);
             });
@@ -915,7 +915,7 @@ describe('Event Tests', () => {
           .redirects(1)
           .expect(201);
         return response.then(() => {
-          return models.Event.findById(event.id).then((editedEvent) => {
+          return models.Event.findByPk(event.id).then((editedEvent) => {
             assert.deepEqual(editedEvent.location, 'edited');
           });
         });

--- a/test/member.js
+++ b/test/member.js
@@ -91,7 +91,7 @@ describe('Member tests', () => {
         .redirects(1)
         .expect(401);
       return response.then(() => {
-        return models.Member.findById(createdMember.id).then((member) => {
+        return models.Member.findByPk(createdMember.id).then((member) => {
           assert.equal(member.super_user, false);
           assert.equal(member.private_user, false);
         });
@@ -124,7 +124,7 @@ describe('Member tests', () => {
         .redirects(1)
         .expect(401);
       return response.then(() => {
-        return models.Member.findById(member.id).then((assertMember) => {
+        return models.Member.findByPk(member.id).then((assertMember) => {
           assert(assertMember);
         });
       });
@@ -141,7 +141,7 @@ describe('Member tests', () => {
         .expect(401);
 
       return response.then(() => {
-        return models.Member.findById(member.id).then((assertMember) => {
+        return models.Member.findByPk(member.id).then((assertMember) => {
           // assumes that the normal user password is 'password'
           return models.Member.comparePassword('password', assertMember).then((truth) => {
             assert(truth);
@@ -222,7 +222,7 @@ describe('Member tests', () => {
         .expect(200);
 
       return response.then(() => {
-        return models.Member.findById(loginMember.id).then((member) => {
+        return models.Member.findByPk(loginMember.id).then((member) => {
           assert(member);
           assert.deepEqual(member.first_name, firstName);
           assert.deepEqual(member.last_name, lastName);
@@ -255,7 +255,7 @@ describe('Member tests', () => {
         .expect(200);
 
       return response.then(() => {
-        return models.Member.findById(loginMember.id).then((member) => {
+        return models.Member.findByPk(loginMember.id).then((member) => {
           assert(member);
           assert.deepEqual(member.first_name, firstName);
           assert.deepEqual(member.last_name, lastName);
@@ -275,7 +275,7 @@ describe('Member tests', () => {
         .redirects(1)
         .expect(200);
       return response.then(() => {
-        return models.Member.findById(loginMember.id).then((member) => {
+        return models.Member.findByPk(loginMember.id).then((member) => {
           assert(member);
           assert.deepEqual(member.grad_year, null);
         });
@@ -297,7 +297,7 @@ describe('Member tests', () => {
           .redirects(1)
           .expect(403);
         return response.then(() => {
-          return models.Member.findById(createdMember.id).then((member) => {
+          return models.Member.findByPk(createdMember.id).then((member) => {
             assert.equal(member.super_user, false);
             assert.equal(member.private_user, false);
           });
@@ -328,7 +328,7 @@ describe('Member tests', () => {
           .redirects(1)
           .expect(403);
         return response.then(() => {
-          return models.Member.findById(member.id).then((assertMember) => {
+          return models.Member.findByPk(member.id).then((assertMember) => {
             assert(assertMember);
           });
         });
@@ -343,7 +343,7 @@ describe('Member tests', () => {
           .expect(403);
 
         return response.then(() => {
-          return models.Member.findById(member.id).then((assertMember) => {
+          return models.Member.findByPk(member.id).then((assertMember) => {
             // assumes that the super user password is 'password'
             return models.Member.comparePassword('password', assertMember).then((truth) => {
               assert(truth);
@@ -381,7 +381,7 @@ describe('Member tests', () => {
           .redirects(1)
           .expect(304);
         return response.then(() => {
-          return models.Member.findById(createdMember.id).then((member) => {
+          return models.Member.findByPk(createdMember.id).then((member) => {
             assert.equal(member.super_user, false);
             assert.equal(member.private_user, false);
           });
@@ -403,7 +403,7 @@ describe('Member tests', () => {
           .redirects(1)
           .expect(200);
         return response.then(() => {
-          return models.Member.findById(createdMember.id).then((member) => {
+          return models.Member.findByPk(createdMember.id).then((member) => {
             assert.equal(member.super_user, true);
             assert.equal(member.private_user, false);
           });
@@ -425,7 +425,7 @@ describe('Member tests', () => {
           .redirects(1)
           .expect(200);
         return response.then(() => {
-          return models.Member.findById(createdMember.id).then((member) => {
+          return models.Member.findByPk(createdMember.id).then((member) => {
             assert.equal(member.super_user, false);
             assert.equal(member.private_user, false);
           });
@@ -447,7 +447,7 @@ describe('Member tests', () => {
           .redirects(1)
           .expect(200);
         return response.then(() => {
-          return models.Member.findById(createdMember.id).then((member) => {
+          return models.Member.findByPk(createdMember.id).then((member) => {
             assert.equal(member.super_user, false);
             assert.equal(member.private_user, true);
           });
@@ -469,7 +469,7 @@ describe('Member tests', () => {
           .redirects(1)
           .expect(200);
         return response.then(() => {
-          return models.Member.findById(createdMember.id).then((member) => {
+          return models.Member.findByPk(createdMember.id).then((member) => {
             assert.equal(member.super_user, false);
             assert.equal(member.private_user, false);
           });
@@ -491,7 +491,7 @@ describe('Member tests', () => {
           .redirects(1)
           .expect(304);
         return response.then(() => {
-          return models.Member.findById(createdMember.id).then((member) => {
+          return models.Member.findByPk(createdMember.id).then((member) => {
             assert.equal(member.super_user, false);
             assert.equal(member.private_user, true);
           });
@@ -522,7 +522,7 @@ describe('Member tests', () => {
           .redirects(1)
           .expect(200);
         return response.then(() => {
-          return models.Member.findById(member.id).then((assertMember) => {
+          return models.Member.findByPk(member.id).then((assertMember) => {
             assert(!assertMember);
           });
         });
@@ -537,7 +537,7 @@ describe('Member tests', () => {
           .expect(200);
 
         return response.then(() => {
-          return models.Member.findById(member.id).then((assertMember) => {
+          return models.Member.findByPk(member.id).then((assertMember) => {
             // assumes that the normal user password is 'password'
             // it's hard to get the new password from the UI, so let's just asser that
             // the password isn't 'password' anymore


### PR DESCRIPTION
Required the following changes:
* Explicitly naming our tables
* Explicitly naming what foreign keys appear as on sequelize objects
* Removing all uses of 'findById' in favor of 'findByPk'

After doing this we can:
* Close #99
* Delete all the greenkeeper/sequelize branches
* Re-enable greenkeeper
* Deploy this code to production - it'll fix a security warning we currently have: [details].(https://nvd.nist.gov/vuln/detail/CVE-2019-11069)