### PR TITLE
Minor Clean Ups

### DIFF
--- a/app.js
+++ b/app.js
@@ -151,8 +151,11 @@ app.use((req, res, next) => {
  * This function doesn't work without 'next' as an argument
  */
 app.use((err, req, res, next) => { /* eslint-disable-line no-unused-vars */
-  // let's log the error so we have it in the logs
-  console.error(err);
+  // don't need to log the whole stack error for 404's
+  if (err.status && err.status != 404) {
+    // let's log the error so we have it in the logs
+    console.error(err);
+  }
   // destructure message from err
   const { message } = err;
 

--- a/app.js
+++ b/app.js
@@ -152,7 +152,7 @@ app.use((req, res, next) => {
  */
 app.use((err, req, res, next) => { /* eslint-disable-line no-unused-vars */
   // don't need to log the whole stack error for 404's
-  if (err.status && err.status != 404) {
+  if (err.status && err.status !== 404) {
     // let's log the error so we have it in the logs
     console.error(err);
   }

--- a/controllers/event.js
+++ b/controllers/event.js
@@ -403,7 +403,6 @@ const postSignup = (req, res, next) => {
       }
       if (!event.public) {
         // Private events are automatically confirmed because they're entered by a super user
-        // TODO - check that user is a super user - only proceed if so
         status = models.Attendance.getStatusConfirmed();
       }
 


### PR DESCRIPTION
I was on an airplane last week and did some very brief clean up tasks.

* Deleted an un-needed TODO
* 404 errors no longer print to the logs. This will clean up unit testing output, but mean that if a requested page 404's for some reason, the error stack won't appear in our logs. The error output is largely useless though, and we will see that a given URL 404'ed.