### PR TITLE
Remove green highlight for future events

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -194,10 +194,6 @@ nav{
   margin-top: 10px;
 }
 
-.event-future {
-  background-color: #ecfee8; 
-}
-
 .event-passed {
   background-color: #ffe7e6; 
 }


### PR DESCRIPTION
Removing the green highlighting for future events as it clashes with the current theme. If the event is not highlighted, it can be automatically assumed it's a future event. 