### PR TITLE
Fix photo misalignment

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -253,9 +253,9 @@ nav{
 }
 
 .member-card .member-photo{
-  margin: 0 auto;
+  object-fit: cover;
+  width: 100%;
   height: 100%;
-  width: auto;
 }
 
 .member-card .image-cropper{
@@ -334,9 +334,9 @@ nav{
 * Member Profile Styling
 *************************/
 .member-photo-lg{
-  margin: 0 auto;
+  object-fit: cover;
+  width: 100%;
   height: 100%;
-  width: auto;
 }
 
 .image-cropper-lg{


### PR DESCRIPTION
For member profile images, if the user uploads an image in a portrait aspect ratio, the cropped circle image is aligned to the left and leaves white space on the side. This will fix that issue. 