### PR TITLE
Update event details page styling and sign up

### DIFF
--- a/controllers/event.js
+++ b/controllers/event.js
@@ -346,6 +346,12 @@ const postSignup = (req, res, next) => {
     memberEmail = req.user.email;
   }
 
+  // Check if it's a full email or a 6+2
+  // Append @mail.uc.edu if it's just a 6+2
+  if (!memberEmail.includes('@')) {
+    memberEmail += '@mail.uc.edu';
+  }
+
   const memberPromise = models.Member.findOne({
     where: {
       email: memberEmail,

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -227,29 +227,38 @@ nav{
   font-weight: 600;
 }
 
-.event .super-container h1{
+.event h2{
+  color: #535353;
   font-weight: 300;
 }
 
 .event .date-loc{
   font-weight: 300;
-  color: #888888;
+  color: #6b6b6b;
 }
 
 .event .super-container{
   margin-top: 40px;
 }
 
-.event .super-container .member-sign-up{
-  padding: 15px 25px;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-  border-radius: 4px;
-  max-width: 600px;
+.event .super-container h1{
+  font-weight: 300;
+  margin-bottom: 20px;
 }
 
-.event .super-container h2{
-  color: #535353;
-  font-weight: 300;
+.event .super-container label{
+  padding-top: 10px;
+}
+
+.event .super-container .super-section{
+  margin-bottom: 30px;
+}
+
+.event .super-container .member-sign-up{
+  padding: 15px 25px;
+  box-shadow: 0 10px 20px -5px rgba(0, 0, 0, 0.1), 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  max-width: 600px;
 }
 
 .event .super-container .member-sign-up h2{
@@ -259,8 +268,25 @@ nav{
 	font-weight: 600;
 }
 
-.event .super-container label{
-  padding-top: 10px;
+.event .super-container .member-sign-up .member-info{
+  display: flex;
+}
+
+.event .super-container .member-sign-up .member-info label{
+  margin-right: 10px;
+}
+
+.event .super-container .member-sign-up .member-info input{
+  width: 40%;
+}
+
+.event .super-container .option-buttons-container {
+  margin-top: 10px;
+  display: flex;
+}
+
+.event .super-container .option-buttons-container .btn {
+  margin-right: 10px;
 }
 
 /*************************
@@ -445,19 +471,25 @@ nav{
 /*************************
 * User Button Styling
 *************************/
-a.user-button{
+a.user-button,
+input.user-button{
 	padding: 10px 40px;
-	color: #b31227;
+  color: #b31227;
+  background: #ffffff;
 	border: 2px solid #b31227;
 	border-radius: 4px;
 	text-decoration: none;
 	transition: 0.2s;
 }
 
-a.user-button:hover{
+a.user-button:hover,
+input.user-button:hover{
   background: #fce8eb;
+  cursor: pointer;
 }
 
-a.user-button:active{
+a.user-button:active,
+input.user-button:active{
   background: #fab7c1;
+  cursor: pointer;
 }

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -221,6 +221,49 @@ nav{
 }
 
 /*************************
+* Event Detail Styling
+*************************/
+.event h1{
+  font-weight: 600;
+}
+
+.event .super-container h1{
+  font-weight: 300;
+}
+
+.event .date-loc{
+  font-weight: 300;
+  color: #888888;
+}
+
+.event .super-container{
+  margin-top: 40px;
+}
+
+.event .super-container .member-sign-up{
+  padding: 15px 25px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  max-width: 600px;
+}
+
+.event .super-container h2{
+  color: #535353;
+  font-weight: 300;
+}
+
+.event .super-container .member-sign-up h2{
+	border-bottom: 2px solid #eaeaea;
+	padding-bottom: 10px;
+	font-size: 1.4rem;
+	font-weight: 600;
+}
+
+.event .super-container label{
+  padding-top: 10px;
+}
+
+/*************************
 * Member Card Styling
 *************************/
 .member-table{

--- a/test/common.js
+++ b/test/common.js
@@ -39,6 +39,13 @@ const getNormalUserEmail = () => {
 };
 exports.getNormalUserEmail = getNormalUserEmail;
 
+const getNormalUsername = () => {
+  const userEmail = getNormalUserEmail();
+  const username = userEmail.substring(0, userEmail.indexOf('@'));
+  return username;
+};
+exports.getNormalUsername = getNormalUsername;
+
 const getSuperUserEmail = () => {
   return 'super@mail.uc.edu';
 };

--- a/test/event.js
+++ b/test/event.js
@@ -289,6 +289,29 @@ describe('Event Tests', () => {
       });
     });
 
+    // POST signup for event with specified username (6+2) as non super user
+    it('POST signup for event by specifying a user as a normal user with username', () => {
+      return common.createPublicEvent().then((event) => {
+        const response = agent
+          .post(`/event/${event.id}/signup`)
+          .send({
+            email: common.getNormalUsername(),
+          })
+          .redirects(1)
+          .expect(403);
+        return response.then(() => {
+          return models.Attendance.findAll({
+            where: {
+              member_id: loginMember.id,
+              event_id: event.id,
+            },
+          }).then((attendances) => {
+            assert.equal(attendances.length, 0);
+          });
+        });
+      });
+    });
+
     // POST signup for a private event as a normal user
     it('POST signup for private event as a normal user', () => {
       return common.createPrivateEvent().then((event) => {
@@ -602,6 +625,31 @@ describe('Event Tests', () => {
       });
     });
 
+    // POST signup with specified username (6+2)
+    it('POST signup for event with specified username', () => {
+      const memberPromise = common.createNormalUser();
+      const eventPromise = common.createPublicEvent();
+      return Promise.all([memberPromise, eventPromise]).then(([member, event]) => {
+        const response = agent
+          .post(`/event/${event.id}/signup`)
+          .send({
+            email: common.getNormalUsername(),
+          })
+          .redirects(1)
+          .expect(201);
+        return response.then(() => {
+          return models.Attendance.findAll({
+            where: {
+              member_id: member.id,
+              event_id: event.id,
+            },
+          }).then((attendances) => {
+            assert.equal(attendances.length, 1);
+          });
+        });
+      });
+    });
+
     // POST signup with not-real email
     it('POST signup for meeting with not real email', () => {
       const memberPromise = common.createNormalUser();
@@ -652,6 +700,31 @@ describe('Event Tests', () => {
       });
     });
 
+    // POST signup succesfully on private event for other user using username (6+2)
+    it('POST signup for private event with specified username', () => {
+      const memberPromise = common.createNormalUser();
+      const eventPromise = common.createPrivateEvent();
+      return Promise.all([memberPromise, eventPromise]).then(([member, event]) => {
+        const response = agent
+          .post(`/event/${event.id}/signup`)
+          .send({
+            email: common.getNormalUsername(),
+          })
+          .redirects(1)
+          .expect(201);
+        return response.then(() => {
+          return models.Attendance.findAll({
+            where: {
+              member_id: member.id,
+              event_id: event.id,
+            },
+          }).then((attendances) => {
+            assert.equal(attendances.length, 1);
+          });
+        });
+      });
+    });
+
     // POST signup succesfully on meeting for other user
     it('POST signup for meeting with specified email', () => {
       const memberPromise = common.createNormalUser();
@@ -661,6 +734,31 @@ describe('Event Tests', () => {
           .post(`/event/${event.id}/signup`)
           .send({
             email: common.getNormalUserEmail(),
+          })
+          .redirects(1)
+          .expect(201);
+        return response.then(() => {
+          return models.Attendance.findAll({
+            where: {
+              member_id: member.id,
+              event_id: event.id,
+            },
+          }).then((attendances) => {
+            assert.equal(attendances.length, 1);
+          });
+        });
+      });
+    });
+
+    // POST signup succesfully on meeting for other user using username (6+2)
+    it('POST signup for meeting with specified username', () => {
+      const memberPromise = common.createNormalUser();
+      const eventPromise = common.createMeeting();
+      return Promise.all([memberPromise, eventPromise]).then(([member, event]) => {
+        const response = agent
+          .post(`/event/${event.id}/signup`)
+          .send({
+            email: common.getNormalUsername(),
           })
           .redirects(1)
           .expect(201);

--- a/views/event/detail.pug
+++ b/views/event/detail.pug
@@ -4,7 +4,7 @@ extends ../layout
 include ../member/mixins/list.pug
 
 block content
-  .detail-container
+  div.detail-container.event
     //- Convert dates to nicer looking values
       date to string adds time zone information we want to remove - split on spaces and remove, then rejoin
     - start_time = String(event.start_time).split(' ').slice(0, 5).join(' ')
@@ -17,9 +17,9 @@ block content
       //- Adds space between first part and second part
       = ' '
       span= event.title
-    div(style="font-size:120%;padding-bottom:20px;") <strong>#{start_time}</strong> - <strong>#{end_time}</strong> at <strong>#{event.location}</strong>
+    div.date-loc
+      p #{start_time} - #{end_time} at #{event.location}
     if event.description
-      h4 Description
       div #{event.description}
 
     //- throw some space in there
@@ -28,7 +28,7 @@ block content
     if user && (!event.meeting || user.super_user)
       form(id='signUp', action='/event/' + event.id + '/signup' , method='post')
         input(type='hidden', name='_csrf', value=csrfToken)
-        input.submit-small(type='submit', name='Sign Up', value='Sign Up For This Event')
+        input.submit-small(type='submit', name='Sign Up', value='Sign Up For Event')
 
     //- throw some space in there
     div(style="padding-top:2%;")
@@ -38,63 +38,64 @@ block content
     else 
       //- Super user only section
         ** EVERYTHING FROM HERE DOWN AT THIS INDENT LEVEL IS SUPER USER ONLY**
-      h1 Super User Only Options
-      
-      //- Sign up another member block
-      h2 Sign Up Another Member
-      form(id='signUpMember', action='/event/' + event.id + '/signup' , method='post')
-        input(type='hidden', name='_csrf', value=csrfToken)
-        div.form-group
-          label Member Email:
-          input.form-control.form-control-sm(type='text', name='email', placeholder='bearcat@mail.uc.edu', style="width:30%;")
-        div.form-group
-          input.submit-small(type='submit', name='Sign Up Member', value='Sign Up Member')
-      
-      //- for events, list members by status
-      if !event.meeting && unconfirmedAttendees.length > 0
-        h2 Confirm Attendance for Unconfirmed Attendees
-        table.table
-          thead
-            tr
-              th Member
-              th Hours
-              th Major
-              th Confirm
-              th Not Needed
-              th Did Not Attend
-          tbody
-            each member in unconfirmedAttendees
+      div.super-container
+        h1 Super User Only Options
+        //- Sign up another member block
+        div.member-sign-up
+          h2 Sign Up Another Member
+          form(id='signUpMember', action='/event/' + event.id + '/signup' , method='post')
+            input(type='hidden', name='_csrf', value=csrfToken)
+            div.form-group
+              label Member 6+2:
+              input.form-control.form-control-sm(type='text', name='email', placeholder='6+2', style="width:30%;")
+            div.form-group
+              input.submit-small(type='submit', name='Sign Up Member', value='Sign Up Member')
+        
+        //- for events, list members by status
+        if !event.meeting && unconfirmedAttendees.length > 0
+          h2 Confirm Attendance for Unconfirmed Attendees
+          table.table
+            thead
               tr
-                td=member.first_name+' '+member.last_name
-                //- Divide service by factor to convert to hours
-                td=(member.service / 3600000)
-                td=(member.major)
-                td
-                  form(id='confirmAttendance', action='/event/' + event.id + '/confirm?member=' + member.id + '&status=confirmed', method='post')
-                    input(type='hidden', name='_csrf', value=csrfToken)
-                    input.submit-small(type='submit', name='Confirm', value='Confirm')
-                td
-                  form(id='notNeededAttendance', action='/event/' + event.id + '/confirm?member=' + member.id + '&status=notNeeded', method='post')
-                    input(type='hidden', name='_csrf', value=csrfToken)
-                    input.submit-small(type='submit', name='NotNeeded', value='Not Needed')
-                td
-                  form(id='denyAttendance', action='/event/' + event.id + '/confirm?member=' + member.id + '&status=denied', method='post')
-                    input(type='hidden', name='_csrf', value=csrfToken)
-                    input.submit-small(type='submit', name='Deny', value='Did Not Attend')
-      //- throw some space in there
-      div(style="padding-top:2%;")
-      if confirmedAttendees.length > 0
-        +member-list(confirmedAttendees, "Confirmed")
-      //- throw some space in there
-      div(style="padding-top:2%;")
-      if notNeededAttendees.length > 0
-        +member-list(notNeededAttendees, "Not needed")
-      
-      //- edit and delete options
-      h2 Event Options
-      a.btn.btn-danger(href='/event/' + event.id + '/edit') Edit Event
-      //- throw some space in there
-      div(style="padding-top:2%;")
-      form(id='deleteEvent', action='/event/' + event.id + '/delete', method='post' onSubmit="return confirm('This will permanently delete the event. Proceed?')")
-        input(type='hidden', name='_csrf', value=csrfToken)
-        input.submit-small(type='submit', name='delete', value='Delete Event')
+                th Member
+                th Hours
+                th Major
+                th Confirm
+                th Not Needed
+                th Did Not Attend
+            tbody
+              each member in unconfirmedAttendees
+                tr
+                  td=member.first_name+' '+member.last_name
+                  //- Divide service by factor to convert to hours
+                  td=(member.service / 3600000)
+                  td=(member.major)
+                  td
+                    form(id='confirmAttendance', action='/event/' + event.id + '/confirm?member=' + member.id + '&status=confirmed', method='post')
+                      input(type='hidden', name='_csrf', value=csrfToken)
+                      input.submit-small(type='submit', name='Confirm', value='Confirm')
+                  td
+                    form(id='notNeededAttendance', action='/event/' + event.id + '/confirm?member=' + member.id + '&status=notNeeded', method='post')
+                      input(type='hidden', name='_csrf', value=csrfToken)
+                      input.submit-small(type='submit', name='NotNeeded', value='Not Needed')
+                  td
+                    form(id='denyAttendance', action='/event/' + event.id + '/confirm?member=' + member.id + '&status=denied', method='post')
+                      input(type='hidden', name='_csrf', value=csrfToken)
+                      input.submit-small(type='submit', name='Deny', value='Did Not Attend')
+        //- throw some space in there
+        div(style="padding-top:2%;")
+        if confirmedAttendees.length > 0
+          +member-list(confirmedAttendees, "Confirmed")
+        //- throw some space in there
+        div(style="padding-top:2%;")
+        if notNeededAttendees.length > 0
+          +member-list(notNeededAttendees, "Not needed")
+        
+        //- edit and delete options
+        h2 Event Options
+        a.btn.btn-danger(href='/event/' + event.id + '/edit') Edit Event
+        //- throw some space in there
+        div(style="padding-top:2%;")
+        form(id='deleteEvent', action='/event/' + event.id + '/delete', method='post' onSubmit="return confirm('This will permanently delete the event. Proceed?')")
+          input(type='hidden', name='_csrf', value=csrfToken)
+          input.submit-small(type='submit', name='delete', value='Delete Event')

--- a/views/event/detail.pug
+++ b/views/event/detail.pug
@@ -20,82 +20,81 @@ block content
     div.date-loc
       p #{start_time} - #{end_time} at #{event.location}
     if event.description
-      div #{event.description}
+      p.description #{event.description}
 
-    //- throw some space in there
-    div(style="padding-top:2%;")
     //- show sign up if it's an event and they're logged in, or if its a meeting and they're a super user
     if user && (!event.meeting || user.super_user)
       form(id='signUp', action='/event/' + event.id + '/signup' , method='post')
         input(type='hidden', name='_csrf', value=csrfToken)
-        input.submit-small(type='submit', name='Sign Up', value='Sign Up For Event')
+        input.user-button(type='submit', name='Sign Up', value='Sign Up For Event')
 
-    //- throw some space in there
-    div(style="padding-top:2%;")
     if !user || (user && !user.super_user)
       //- Show normal users a combination of unconfirmed and confirmed members
-      +member-list(unconfirmedAndConfirmedAttendees, "Attendees")
+      +member-list(unconfirmedAndConfirmedAttendees, "Attendees", "h2")
     else 
       //- Super user only section
         ** EVERYTHING FROM HERE DOWN AT THIS INDENT LEVEL IS SUPER USER ONLY**
       div.super-container
-        h1 Super User Only Options
-        //- Sign up another member block
-        div.member-sign-up
-          h2 Sign Up Another Member
-          form(id='signUpMember', action='/event/' + event.id + '/signup' , method='post')
-            input(type='hidden', name='_csrf', value=csrfToken)
-            div.form-group
-              label Member 6+2:
-              input.form-control.form-control-sm(type='text', name='email', placeholder='6+2', style="width:30%;")
-            div.form-group
-              input.submit-small(type='submit', name='Sign Up Member', value='Sign Up Member')
-        
-        //- for events, list members by status
-        if !event.meeting && unconfirmedAttendees.length > 0
-          h2 Confirm Attendance for Unconfirmed Attendees
-          table.table
-            thead
-              tr
-                th Member
-                th Hours
-                th Major
-                th Confirm
-                th Not Needed
-                th Did Not Attend
-            tbody
-              each member in unconfirmedAttendees
+        div.super-section
+          h1 Super User Only Options
+          //- Sign up another member block
+          div.member-sign-up
+            h2 Sign Up Another Member
+            form(id='signUpMember', action='/event/' + event.id + '/signup' , method='post')
+              input(type='hidden', name='_csrf', value=csrfToken)
+              div.form-group.member-info
+                label Member 6+2:
+                input.form-control.form-control-sm(type='text', name='email', placeholder='6+2')
+              div.form-group
+                input.submit-small(type='submit', name='Sign Up Member', value='Sign Up Member')
+
+        div.super-section
+          //- for events, list members by status
+          if !event.meeting && unconfirmedAttendees.length > 0
+            h2 Confirm Attendance for Unconfirmed Attendees
+            table.table
+              thead
                 tr
-                  td=member.first_name+' '+member.last_name
-                  //- Divide service by factor to convert to hours
-                  td=(member.service / 3600000)
-                  td=(member.major)
-                  td
-                    form(id='confirmAttendance', action='/event/' + event.id + '/confirm?member=' + member.id + '&status=confirmed', method='post')
-                      input(type='hidden', name='_csrf', value=csrfToken)
-                      input.submit-small(type='submit', name='Confirm', value='Confirm')
-                  td
-                    form(id='notNeededAttendance', action='/event/' + event.id + '/confirm?member=' + member.id + '&status=notNeeded', method='post')
-                      input(type='hidden', name='_csrf', value=csrfToken)
-                      input.submit-small(type='submit', name='NotNeeded', value='Not Needed')
-                  td
-                    form(id='denyAttendance', action='/event/' + event.id + '/confirm?member=' + member.id + '&status=denied', method='post')
-                      input(type='hidden', name='_csrf', value=csrfToken)
-                      input.submit-small(type='submit', name='Deny', value='Did Not Attend')
-        //- throw some space in there
-        div(style="padding-top:2%;")
-        if confirmedAttendees.length > 0
-          +member-list(confirmedAttendees, "Confirmed")
-        //- throw some space in there
-        div(style="padding-top:2%;")
-        if notNeededAttendees.length > 0
-          +member-list(notNeededAttendees, "Not needed")
+                  th Member
+                  th Hours
+                  th Major
+                  th Confirm
+                  th Not Needed
+                  th Did Not Attend
+              tbody
+                each member in unconfirmedAttendees
+                  tr
+                    td=member.first_name+' '+member.last_name
+                    //- Divide service by factor to convert to hours
+                    td=(member.service / 3600000)
+                    td=(member.major)
+                    td
+                      form(id='confirmAttendance', action='/event/' + event.id + '/confirm?member=' + member.id + '&status=confirmed', method='post')
+                        input(type='hidden', name='_csrf', value=csrfToken)
+                        input.submit-small(type='submit', name='Confirm', value='Confirm')
+                    td
+                      form(id='notNeededAttendance', action='/event/' + event.id + '/confirm?member=' + member.id + '&status=notNeeded', method='post')
+                        input(type='hidden', name='_csrf', value=csrfToken)
+                        input.submit-small(type='submit', name='NotNeeded', value='Not Needed')
+                    td
+                      form(id='denyAttendance', action='/event/' + event.id + '/confirm?member=' + member.id + '&status=denied', method='post')
+                        input(type='hidden', name='_csrf', value=csrfToken)
+                        input.submit-small(type='submit', name='Deny', value='Did Not Attend')
         
-        //- edit and delete options
-        h2 Event Options
-        a.btn.btn-danger(href='/event/' + event.id + '/edit') Edit Event
-        //- throw some space in there
-        div(style="padding-top:2%;")
-        form(id='deleteEvent', action='/event/' + event.id + '/delete', method='post' onSubmit="return confirm('This will permanently delete the event. Proceed?')")
-          input(type='hidden', name='_csrf', value=csrfToken)
-          input.submit-small(type='submit', name='delete', value='Delete Event')
+        div.super-section
+          if confirmedAttendees.length > 0
+            +member-list(confirmedAttendees, "Confirmed", "h2")
+
+        div.super-section
+          if notNeededAttendees.length > 0
+            +member-list(notNeededAttendees, "Not needed", "h2")
+        
+        div.super-section
+          //- edit and delete options
+          h2 Event Options
+          div.option-buttons-container
+            a.btn.btn-danger(href='/event/' + event.id + '/edit') Edit Event
+
+            form(id='deleteEvent', action='/event/' + event.id + '/delete', method='post' onSubmit="return confirm('This will permanently delete the event. Proceed?')")
+              input(type='hidden', name='_csrf', value=csrfToken)
+              input.submit-small(type='submit', name='delete', value='Delete Event')

--- a/views/member/mixins/list.pug
+++ b/views/member/mixins/list.pug
@@ -5,7 +5,7 @@
 include ./card.pug
 
 mixin member-list(members, title)
-  h1=title
+  h2=title
   div.member-table
     each member in members
       +member-card(member)

--- a/views/member/mixins/list.pug
+++ b/views/member/mixins/list.pug
@@ -4,8 +4,14 @@
 //- import member-card mixin
 include ./card.pug
 
-mixin member-list(members, title)
-  h2=title
+mixin member-list(members, title, heading='h1')
+  if heading == 'h1'
+    h1=title
+  else if heading == 'h2'
+    h2=title
+  else if heading == 'h3'
+    h3=title
+    
   div.member-table
     each member in members
       +member-card(member)


### PR DESCRIPTION
Addressing #126 to allow members to sign up using their 6+2 username instead of their entire email (though, it's still possible to sign up using an email). New test cases have been put in place for this feature.

Also addressing #56 by removing all of the inline styles and adding it to style.css. I've updated the general styling of the page to better match the rest of the website. One important styling change added is the separation of the another member sign-up section by making it into a card. The reason for this is that new members have the tendency of clicking on the "Sign Up For Event" button instead of the "Sign Up Member" button. I also changed the styling of the user buttons to differentiate them from the superuser buttons. 